### PR TITLE
feat: claim gan images

### DIFF
--- a/artist-block-backend-netcore-services/account-service/Controllers/GanController/GanController.cs
+++ b/artist-block-backend-netcore-services/account-service/Controllers/GanController/GanController.cs
@@ -1,0 +1,55 @@
+﻿using System.Security.Claims;
+using account_service.DTO.Gan;
+using account_service.Service.GanService;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace account_service.Controllers.GanController;
+
+[Route("api/v1")]
+[ApiController]
+public class GanController : ControllerBase
+{
+
+    private readonly IGanService _ganService;
+
+    public GanController(IGanService ganService)
+    {
+        _ganService = ganService;
+    }
+    
+    [HttpPost]
+    [Route("gan-image/claim")]
+    [Authorize]
+    public async Task<ActionResult> UploadImage(ClaimGanImageDto claimGanImageDto)
+    {
+        try
+        {   
+            var auth0UserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            // TODO: Create A Mapper Once The Object Becomes Bigger
+            await _ganService.ClaimGanImage(claimGanImageDto.Description, auth0UserId);
+            return Ok("Image Saved!");
+        }
+        catch (Exception e) {
+            Console.WriteLine(e);
+            return Problem(e.GetBaseException().ToString());
+        }
+    }
+
+    [HttpPost]
+    [Route("gan-image/upload/{ganPaintingId}")]
+    [Authorize]
+    public async Task<ActionResult> UploadImage(IFormFile image, Guid ganPaintingId)
+    {
+        try
+        {   
+            var auth0UserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            await _ganService.UploadImage(image, auth0UserId,ganPaintingId);
+            return Ok("Image Saved!");
+        }
+        catch (Exception e) {
+            Console.WriteLine(e);
+            return Problem(e.GetBaseException().ToString());
+        }
+    }
+}

--- a/artist-block-backend-netcore-services/account-service/Controllers/GanController/GanController.cs
+++ b/artist-block-backend-netcore-services/account-service/Controllers/GanController/GanController.cs
@@ -53,7 +53,7 @@ public class GanController : ControllerBase
         }
     } 
     
-    [HttpPost]
+    [HttpGet]
     [Route("gan-image/collection")]
     [Authorize]
     public ActionResult GetAllClaimedGanImagesForClient()

--- a/artist-block-backend-netcore-services/account-service/Controllers/GanController/GanController.cs
+++ b/artist-block-backend-netcore-services/account-service/Controllers/GanController/GanController.cs
@@ -51,5 +51,25 @@ public class GanController : ControllerBase
             Console.WriteLine(e);
             return Problem(e.GetBaseException().ToString());
         }
+    } 
+    
+    [HttpPost]
+    [Route("gan-image/collection")]
+    [Authorize]
+    public ActionResult GetAllClaimedGanImagesForClient()
+    {
+        try
+        {   
+            
+            var auth0UserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        
+            var ganImagesList = _ganService.GetAllClaimedGanImagesForClient(auth0UserId);
+            //TODO: READ MAPPER IS NEEDED 
+            return Ok(ganImagesList);
+        }
+        catch (Exception e) {
+            Console.WriteLine(e);
+            return Problem(e.GetBaseException().ToString());
+        }
     }
 }

--- a/artist-block-backend-netcore-services/account-service/DTO/Gan/ClaimGanImageDto.cs
+++ b/artist-block-backend-netcore-services/account-service/DTO/Gan/ClaimGanImageDto.cs
@@ -1,0 +1,9 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace account_service.DTO.Gan;
+
+public class ClaimGanImageDto
+{
+    [Required]
+    public string?  Description { get; set; }
+}

--- a/artist-block-backend-netcore-services/account-service/Migrations/ArtistBlockDbContextModelSnapshot.cs
+++ b/artist-block-backend-netcore-services/account-service/Migrations/ArtistBlockDbContextModelSnapshot.cs
@@ -39,6 +39,34 @@ namespace account_service.Migrations
                     b.ToTable("auth_user");
                 });
 
+            modelBuilder.Entity("account_service.Models.GanGeneratedImage", b =>
+                {
+                    b.Property<Guid>("GanImageId")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid")
+                        .HasColumnName("PK_gan_image_id");
+
+                    b.Property<string>("Description")
+                        .IsRequired()
+                        .HasColumnType("text")
+                        .HasColumnName("gan_image_description");
+
+                    b.Property<string>("ImageUrl")
+                        .IsRequired()
+                        .HasColumnType("text")
+                        .HasColumnName("gan_image_url");
+
+                    b.Property<Guid?>("RegisteredUserId")
+                        .HasColumnType("uuid")
+                        .HasColumnName("FK_painting_registered_user_id");
+
+                    b.HasKey("GanImageId");
+
+                    b.HasIndex("RegisteredUserId");
+
+                    b.ToTable("gan_image");
+                });
+
             modelBuilder.Entity("account_service.Models.Painter", b =>
                 {
                     b.Property<Guid>("PainterId")
@@ -233,6 +261,13 @@ namespace account_service.Migrations
                     b.Navigation("RegisteredUser");
                 });
 
+            modelBuilder.Entity("account_service.Models.GanGeneratedImage", b =>
+                {
+                    b.HasOne("account_service.Models.RegisteredUser", null)
+                        .WithMany("ClaimedGanImages")
+                        .HasForeignKey("RegisteredUserId");
+                });
+
             modelBuilder.Entity("account_service.Models.Painter", b =>
                 {
                     b.HasOne("account_service.Models.RegisteredUser", "RegisteredUser")
@@ -283,6 +318,8 @@ namespace account_service.Migrations
 
             modelBuilder.Entity("account_service.Models.RegisteredUser", b =>
                 {
+                    b.Navigation("ClaimedGanImages");
+
                     b.Navigation("Painter")
                         .IsRequired();
 

--- a/artist-block-backend-netcore-services/account-service/Models/GanGeneratedImage.cs
+++ b/artist-block-backend-netcore-services/account-service/Models/GanGeneratedImage.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace account_service.Models;
+
+[Table("gan_image")]
+public class GanGeneratedImage
+{
+    [Key]
+    [Column("PK_gan_image_id")]
+    public Guid GanImageId{ get; set; }
+        
+    [Required]
+    [Column("gan_image_description")]
+    public string?  Description { get; set; }
+    
+    [Required]
+    [Column("gan_image_url")]
+    public string?  ImageUrl { get; set; }  
+    
+    
+    [Column("FK_painting_registered_user_id")]
+    public Guid? RegisteredUserId { get; set; }
+    
+
+}

--- a/artist-block-backend-netcore-services/account-service/Models/RegisteredUser.cs
+++ b/artist-block-backend-netcore-services/account-service/Models/RegisteredUser.cs
@@ -48,5 +48,8 @@ public class RegisteredUser {
 
     
     public virtual ICollection<Painting>? PaintingsBought { get; set; }
+    
+    public virtual ICollection<GanGeneratedImage>? ClaimedGanImages { get; set; }
+
         
 }

--- a/artist-block-backend-netcore-services/account-service/Repository/ArtistBlockDbContext.cs
+++ b/artist-block-backend-netcore-services/account-service/Repository/ArtistBlockDbContext.cs
@@ -15,6 +15,7 @@ public class ArtistBlockDbContext: DbContext {
         public DbSet<Models.AuthUser> AuthUsers { get; set; }
         public DbSet<Models.Speciality> Specialities { get; set; }
         public DbSet<Models.PainterSpeciality> PainterSpecialities { get; set; }
+        public DbSet<Models.GanGeneratedImage> GanGeneratedImages { get; set; }
         
         public DbSet<Models.Painting> Paintings { get; set; }
 

--- a/artist-block-backend-netcore-services/account-service/Repository/GanRepo/GanRepo.cs
+++ b/artist-block-backend-netcore-services/account-service/Repository/GanRepo/GanRepo.cs
@@ -1,0 +1,31 @@
+﻿using account_service.Models;
+
+namespace account_service.Repository.GanRepo;
+
+public class GanRepo: IGanRepo
+{
+    private readonly ArtistBlockDbContext _context;
+
+    public GanRepo(ArtistBlockDbContext context)
+    {
+        _context = context;
+    }
+
+    public GanGeneratedImage GetPaintingInformation(Guid ganPaintingId)
+    {
+        return _context.GanGeneratedImages.FirstOrDefault(gan => gan.GanImageId.Equals(ganPaintingId));
+    }
+
+    public Task AddGanImageReference(GanGeneratedImage currentGanImage, string url)
+    {
+        currentGanImage.ImageUrl = url;
+        _context.SaveChanges();
+        return Task.CompletedTask;
+    }
+
+    public void ClaimGanImage(GanGeneratedImage generatedImage)
+    {
+        _context.GanGeneratedImages.Add(generatedImage);
+        _context.SaveChanges();
+    }
+}

--- a/artist-block-backend-netcore-services/account-service/Repository/GanRepo/GanRepo.cs
+++ b/artist-block-backend-netcore-services/account-service/Repository/GanRepo/GanRepo.cs
@@ -28,4 +28,10 @@ public class GanRepo: IGanRepo
         _context.GanGeneratedImages.Add(generatedImage);
         _context.SaveChanges();
     }
+
+    public IEnumerable<GanGeneratedImage> GetAllClaimedGanImagesForClient(Guid userId)
+    {
+        var ganList = _context.GanGeneratedImages.Where(ganImg => ganImg.RegisteredUserId.Equals(userId));
+        return ganList;
+    }
 }

--- a/artist-block-backend-netcore-services/account-service/Repository/GanRepo/IGanRepo.cs
+++ b/artist-block-backend-netcore-services/account-service/Repository/GanRepo/IGanRepo.cs
@@ -1,4 +1,5 @@
 ﻿using account_service.Models;
+using account_service.ValueObjects;
 
 namespace account_service.Repository.GanRepo;
 
@@ -7,4 +8,5 @@ public interface IGanRepo
     GanGeneratedImage GetPaintingInformation(Guid ganPaintingId);
     Task AddGanImageReference(GanGeneratedImage currentGanImage, string url);
     void ClaimGanImage(GanGeneratedImage ganGeneratedImage);
+    IEnumerable<GanGeneratedImage> GetAllClaimedGanImagesForClient(Guid userId);
 }

--- a/artist-block-backend-netcore-services/account-service/Repository/GanRepo/IGanRepo.cs
+++ b/artist-block-backend-netcore-services/account-service/Repository/GanRepo/IGanRepo.cs
@@ -1,0 +1,10 @@
+﻿using account_service.Models;
+
+namespace account_service.Repository.GanRepo;
+
+public interface IGanRepo
+{
+    GanGeneratedImage GetPaintingInformation(Guid ganPaintingId);
+    Task AddGanImageReference(GanGeneratedImage currentGanImage, string url);
+    void ClaimGanImage(GanGeneratedImage ganGeneratedImage);
+}

--- a/artist-block-backend-netcore-services/account-service/Service/GanService/GanService.cs
+++ b/artist-block-backend-netcore-services/account-service/Service/GanService/GanService.cs
@@ -1,0 +1,65 @@
+﻿using account_service.Models;
+using account_service.Repository.GanRepo;
+using account_service.Service.CurrentLoggedInService;
+using account_service.Service.RegistrationService;
+using Microsoft.EntityFrameworkCore.Internal;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Blob;
+
+namespace account_service.Service.GanService;
+
+public class GanService: IGanService
+{
+    private readonly IGanRepo _ganRepo;
+    private readonly IConfiguration _configuration;
+    private readonly ICurrentLoggedInService _currentLoggedInService;
+
+    public GanService(IGanRepo ganRepo, IConfiguration configuration, ICurrentLoggedInService currentLoggedInService)
+    {
+        _ganRepo = ganRepo;
+        _configuration = configuration;
+        _currentLoggedInService = currentLoggedInService;
+    }
+
+    public async Task UploadImage(IFormFile image, string auth0UserId, Guid ganPaintingId)
+    {
+        var currentLoggedInUser = _currentLoggedInService.GetCurrentLoggedInUser(auth0UserId);
+        var currentGanImage = _ganRepo.GetPaintingInformation(ganPaintingId);
+        string systemFileName = currentLoggedInUser.RegisteredUser.RegisteredUserId + image.FileName;
+        currentGanImage.ImageUrl = systemFileName;
+        
+            string blobstorageconnection = _configuration.GetValue<string>("BlobConnectionString");  
+            // Retrieve storage account from connection string.    
+            CloudStorageAccount cloudStorageAccount = CloudStorageAccount.Parse(blobstorageconnection);  
+            // Create the blob client.    
+            CloudBlobClient blobClient = cloudStorageAccount.CreateCloudBlobClient();  
+            // Retrieve a reference to a container.    
+            CloudBlobContainer container = blobClient.GetContainerReference(_configuration.GetValue<string>("BlobContainerGanPaintingName"));  
+            // This also does not make a service call; it only creates a local object.    
+            CloudBlockBlob blockBlob = container.GetBlockBlobReference(systemFileName);
+            
+            await using(var data = image.OpenReadStream()) {  
+                await blockBlob.UploadFromStreamAsync(data);  
+            }
+        
+            await _ganRepo.AddGanImageReference(currentGanImage, blockBlob.Uri.ToString());
+        
+        
+    }
+
+    public Task ClaimGanImage(string? description, string auth0UserId)
+    {
+        Guid ganPaintingId = Guid.NewGuid();
+        var RegisteredIdForCurrentLoggedInUser = _currentLoggedInService.GetCurrentLoggedInUser(auth0UserId).RegisteredUser.RegisteredUserId;
+        GanGeneratedImage ganGeneratedImage = new GanGeneratedImage()
+        {
+            Description = description,
+            GanImageId = ganPaintingId,
+           RegisteredUserId = RegisteredIdForCurrentLoggedInUser,
+           //TODO: Remove Required Field for Image URL at This stage
+           ImageUrl = "",
+        };
+        _ganRepo.ClaimGanImage(ganGeneratedImage);
+        return Task.CompletedTask;
+    }
+}

--- a/artist-block-backend-netcore-services/account-service/Service/GanService/GanService.cs
+++ b/artist-block-backend-netcore-services/account-service/Service/GanService/GanService.cs
@@ -62,4 +62,10 @@ public class GanService: IGanService
         _ganRepo.ClaimGanImage(ganGeneratedImage);
         return Task.CompletedTask;
     }
+
+    public IEnumerable<GanGeneratedImage> GetAllClaimedGanImagesForClient(string auth0UserId)
+    {
+        var userId = _currentLoggedInService.GetCurrentLoggedInUser(auth0UserId).RegisteredUser.RegisteredUserId;
+        return _ganRepo.GetAllClaimedGanImagesForClient(userId);
+    }
 }

--- a/artist-block-backend-netcore-services/account-service/Service/GanService/IGanService.cs
+++ b/artist-block-backend-netcore-services/account-service/Service/GanService/IGanService.cs
@@ -1,0 +1,7 @@
+﻿namespace account_service.Service.GanService;
+
+public interface IGanService
+{
+    Task UploadImage(IFormFile image, string auth0UserId, Guid ganPaintingId);
+    Task ClaimGanImage(string? description, string auth0UserId);
+}

--- a/artist-block-backend-netcore-services/account-service/Service/GanService/IGanService.cs
+++ b/artist-block-backend-netcore-services/account-service/Service/GanService/IGanService.cs
@@ -1,7 +1,10 @@
-﻿namespace account_service.Service.GanService;
+﻿using account_service.Models;
+
+namespace account_service.Service.GanService;
 
 public interface IGanService
 {
     Task UploadImage(IFormFile image, string auth0UserId, Guid ganPaintingId);
     Task ClaimGanImage(string? description, string auth0UserId);
+    IEnumerable<GanGeneratedImage> GetAllClaimedGanImagesForClient(string auth0UserId);
 }

--- a/artist-block-backend-netcore-services/account-service/Startup.cs
+++ b/artist-block-backend-netcore-services/account-service/Startup.cs
@@ -2,11 +2,13 @@
 using System.Text.Json.Serialization;
 using account_service.Models;
 using account_service.Repository;
+using account_service.Repository.GanRepo;
 using account_service.Repository.PaintingRepo;
 using account_service.Repository.RegistrationRepo;
 using account_service.Service.PaintingService;
 using account_service.Repository.SpecialityRepo;
 using account_service.Service.CurrentLoggedInService;
+using account_service.Service.GanService;
 using account_service.Service.RegistrationService;
 using account_service.Service.SpecialityService;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -48,7 +50,8 @@ namespace account_service{
             services.AddScoped<ISpecialityRepo, SpecialityRepo>();
             services.AddScoped<ISpecialityService, SpecialityService>();
 
-
+            services.AddScoped<IGanService, GanService>();
+            services.AddScoped<IGanRepo, GanRepo>();
 
             services.AddScoped<ICurrentLoggedInService, CurrentLoggedInService>();
 

--- a/artist-block-backend-netcore-services/account-service/appsettings.json
+++ b/artist-block-backend-netcore-services/account-service/appsettings.json
@@ -23,6 +23,7 @@
 
   "BlobContainerImageName": "images",
   "BlobContainerPaintingName": "painting",
+  "BlobContainerGanPaintingName": "gan",
   "BlobConnectionString": "DefaultEndpointsProtocol=https;AccountName=artistblockstorage;AccountKey=cbf1BfgLNZzCnfj+pqHUrDxCbcX+o120OxeSotYr0ZeHfCAvErcXapFbNw6esGfHOsx88K8SYg/++AStpshMaA==;EndpointSuffix=core.windows.net"
 
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/45897168/161723686-d1d8093b-b227-4f21-81dc-cde3ec58dc42.png)


First you claim the generated gan image (since you can ignore and re generate a new one from the UI).
After claiming you should upload the image to azure (this is done because sending the request and image on the same endpoint is causing problems)
Thrid endpoint, a user can check all of his gan images collection